### PR TITLE
Delay dependencies loading and support addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 npm install @openzeppelin/contract-loader
 ```
 
-You will also need to install `web3-eth-contract` and/or `@truffle/contract`, depending on which abstractions you want to be able to load.
+You may also need to install `web3-eth-contract` or `@truffle/contract`, depending on which abstractions you want to be able to load.
 
 ## Usage
 
@@ -21,13 +21,15 @@ You will also need to install `web3-eth-contract` and/or `@truffle/contract`, de
 const { setupLoader } = require('@openzeppelin/contract-loader');
 
 const loader = setupLoader({
-  provider,
+  provider,      // either a web3 provider or a web3 instance
   defaultSender, // optional
-  defaultGas, // optional - defaults to 8 million
+  defaultGas,    // optional, defaults to 8 million
 });
 ```
 
 ### Loading web3 contracts
+
+When loading web3 contracts, you will need to either pass a `web3` instance as a `provider`, or install the peer dependency `web3-eth-contract`.
 
 ```javascript
 const web3Loader = loader.web3;
@@ -36,11 +38,20 @@ const web3Loader = loader.web3;
 const ERC20 = web3Loader.fromArtifact('ERC20');
 
 // Or load directly from an ABI
-const abi = [ ... ];
+const abi = [{ 
+  "constant": true, 
+  "name": "totalSupply", 
+  "outputs": [{"internalType": "uint256", "type": "uint256"}],
+  "type": "function"
+}];
 const ERC20 = web3Loader.fromABI(abi);
 
 // Deploy token
 const token = await ERC20.deploy().send();
+
+// Or load from artifact at a specific address
+const address = token.options.address;
+const theSameToken = web3Loader.fromArtifact('ERC20', address);
 
 // Query blockchain state and send transactions
 const balance = await token.methods.balanceOf(sender).call();
@@ -49,6 +60,8 @@ await token.methods.transfer(receiver, balance).send({ from: sender });
 
 ### Loading truffle contracts
 
+When loading truffle contracts, you will need to install the `@truffle/contract` dependency.
+
 ```javascript
 const truffleLoader = loader.truffle;
 
@@ -56,7 +69,12 @@ const truffleLoader = loader.truffle;
 const ERC20 = truffleLoader.fromArtifact('ERC20');
 
 // Or load directly from an ABI
-const abi = [ ... ];
+const abi = [{ 
+  "constant": true, 
+  "name": "totalSupply", 
+  "outputs": [{"internalType": "uint256", "type": "uint256"}],
+  "type": "function"
+}];
 const ERC20 = truffleLoader.fromABI(abi);
 
 // Deploy token

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ interface LoaderConfig {
   defaultGas: number;
 }
 
+interface Loader {
+  fromABI(abi: object, bytecode?: string, address?: string): any;
+  fromArtifact(name: string, address?: string): any;
+}
+
 function artifactsDir(buildDir: string): string {
   return `${buildDir}/contracts`;
 }
@@ -23,57 +28,92 @@ function loadArtifact(contract: string) {
   return readJSONSync(`${artifactsDir(buildDir)}/${contract}.json`, { encoding: 'utf8' });
 }
 
-function web3Loader(provider: any, defaultSender: string, defaultGas: number) {
-  const web3Contract = tryRequire('web3-eth-contract');
-  if (web3Contract === undefined) {
-    throw new Error(
-      "Could not load package 'web3-eth-contract'. Please install it alongisde @openzeppelin/contract-loader.",
-    );
+abstract class BaseLoader implements Loader {
+  web3?: any;
+  provider: any;
+  defaultSender: string;
+  defaultGas: number;
+
+  constructor(providerOrWeb3: any, defaultSender: string, defaultGas: number) {
+    if (providerOrWeb3.currentProvider) {
+      this.provider = providerOrWeb3.currentProvider;
+      this.web3 = providerOrWeb3;
+    } else {
+      this.provider = providerOrWeb3;
+    }
+
+    this.defaultSender = defaultSender;
+    this.defaultGas = defaultGas;
   }
 
-  web3Contract.setProvider(provider);
-
-  function fromABI(abi: object, bytecode = '') {
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    return new web3Contract(abi, undefined, { data: bytecode, from: defaultSender, gas: defaultGas });
-  }
-
-  function fromArtifact(contract: string) {
+  public fromArtifact(contract: string, address?: string): any {
     const { abi, bytecode } = loadArtifact(contract);
-    return fromABI(abi, bytecode);
+    return this.fromABI(abi, bytecode, address);
   }
 
-  return { fromABI, fromArtifact };
+  public abstract fromABI(abi: object, bytecode?: string, address?: string): any;
 }
 
-function truffleLoader(provider: any, defaultSender: string, defaultGas: number) {
-  const truffleContract = tryRequire('@truffle/contract');
-  if (truffleContract === undefined) {
-    throw new Error(
-      "Could not load package '@truffle/contract'. Please install it alongisde @openzeppelin/contract-loader.",
-    );
+export class Web3Loader extends BaseLoader {
+  private _web3Contract: any;
+
+  public fromABI(abi: object, bytecode?: string, address?: string): any {
+    return new this.web3Contract(abi, address, { data: bytecode, from: this.defaultSender, gas: this.defaultGas });
   }
 
-  function fromABI(abi: object, bytecode = '') {
-    // eslint-disable-next-line @typescript-eslint/camelcase
-    const abstraction = truffleContract({ abi, unlinked_binary: bytecode });
-    abstraction.setProvider(provider);
-    abstraction.defaults({ from: defaultSender, gas: defaultGas });
+  protected get web3Contract(): any {
+    if (this._web3Contract === undefined) {
+      // If we only have a web3 provider, then we need to require web3-eth-contract
+      if (this.web3 === undefined) {
+        const lib = tryRequire('web3-eth-contract');
+        if (lib === undefined) {
+          throw new Error(
+            "Could not load package 'web3-eth-contract'. Please install it alongisde @openzeppelin/contract-loader.",
+          );
+        }
+        lib.setProvider(this.provider);
+        this._web3Contract = lib;
+      }
+      // Otherwise, we can use the web3.eth.Contract directly, and not require any extra deps
+      else {
+        this._web3Contract = this.web3.eth.Contract;
+      }
+    }
 
+    return this._web3Contract;
+  }
+}
+
+export class TruffleLoader extends BaseLoader {
+  private _truffleContract: any;
+
+  public fromABI(abi: object, bytecode?: string, address?: string) {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    const abstraction = this.truffleContract({ abi, unlinked_binary: bytecode });
+    abstraction.setProvider(this.provider);
+    abstraction.defaults({ from: this.defaultSender, gas: this.defaultGas });
+
+    if (address !== undefined) return new abstraction(address);
     return abstraction;
   }
 
-  function fromArtifact(contract: string) {
-    const { abi, bytecode } = loadArtifact(contract);
-    return fromABI(abi, bytecode);
+  protected get truffleContract(): any {
+    if (this._truffleContract === undefined) {
+      const lib = tryRequire('@truffle/contract');
+      if (lib === undefined) {
+        throw new Error(
+          "Could not load package '@truffle/contract'. Please install it alongisde @openzeppelin/contract-loader.",
+        );
+      }
+      this._truffleContract = lib;
+    }
+    return this._truffleContract;
   }
-
-  return { fromABI, fromArtifact };
 }
 
-export function setupLoader({ provider, defaultSender = '', defaultGas = 8e6 }: LoaderConfig) {
+export function setupLoader({ provider, defaultSender, defaultGas = 8e6 }: LoaderConfig) {
   return {
-    web3: web3Loader(provider, defaultSender, defaultGas),
-    truffle: truffleLoader(provider, defaultSender, defaultGas),
+    web3: new Web3Loader(provider, defaultSender, defaultGas),
+    truffle: new TruffleLoader(provider, defaultSender, defaultGas),
   };
 }

--- a/test/direct-dependency/contracts/Foo.sol
+++ b/test/direct-dependency/contracts/Foo.sol
@@ -1,8 +1,14 @@
 pragma solidity ^0.5.0;
 
 contract Foo {
+  uint256 public value;
 
   function bar() public pure returns (string memory) {
     return "bar";
+  }
+
+  function set(uint256 _value) public returns (uint256) {
+    value = _value;
+    return value;
   }
 }

--- a/test/direct-dependency/package.json
+++ b/test/direct-dependency/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.2.0",
+    "chai-bn": "^0.2.0",
     "truffle": "^5.0.43"
   },
   "dependencies": {


### PR DESCRIPTION
This PR covers the following:
- Refactor loader functions into actual classes
- Add an overload for loading a specific contract (fixes #8)
- Load dependencies only when needed (fixes #7)
- Support passing a web3 instance instead of provider