### PR TITLE
Tweak loader options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class TruffleLoader extends BaseLoader {
   }
 }
 
-export function setupLoader({ provider, defaultSender, defaultGas = 8e6 }: LoaderConfig) {
+export function setupLoader({ provider, defaultSender, defaultGas = 4e6 }: LoaderConfig) {
   return {
     web3: new Web3Loader(provider, defaultSender, defaultGas),
     truffle: new TruffleLoader(provider, defaultSender, defaultGas),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import { join } from 'path';
 
 interface LoaderConfig {
   provider: any;
-  defaultSender: string;
-  defaultGas: number;
+  defaultSender?: string;
+  defaultGas?: number;
 }
 
 interface Loader {
@@ -42,10 +42,10 @@ function loadArtifact(contract: string): any {
 abstract class BaseLoader implements Loader {
   web3?: any;
   provider: any;
-  defaultSender: string;
-  defaultGas: number;
+  defaultSender?: string;
+  defaultGas?: number;
 
-  constructor(providerOrWeb3: any, defaultSender: string, defaultGas: number) {
+  constructor(providerOrWeb3: any, defaultSender?: string, defaultGas?: number) {
     if (providerOrWeb3.currentProvider) {
       this.provider = providerOrWeb3.currentProvider;
       this.web3 = providerOrWeb3;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,9 @@ import findUp from 'find-up';
 import tryRequire from 'try-require';
 import { join } from 'path';
 
+const DEFAULT_GAS = 2e5;
+const DEFAULT_GAS_PRICE = 1e9;
+
 interface LoaderConfig {
   provider: any;
   defaultSender?: string;
@@ -134,7 +137,12 @@ export class TruffleLoader extends BaseLoader {
   }
 }
 
-export function setupLoader({ provider, defaultSender, defaultGas = 4e6, defaultGasPrice = 1e9 }: LoaderConfig) {
+export function setupLoader({
+  provider,
+  defaultSender,
+  defaultGas = DEFAULT_GAS,
+  defaultGasPrice = DEFAULT_GAS_PRICE,
+}: LoaderConfig) {
   return {
     web3: new Web3Loader(provider, defaultSender, defaultGas, defaultGasPrice),
     truffle: new TruffleLoader(provider, defaultSender, defaultGas, defaultGasPrice),

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ interface LoaderConfig {
   provider: any;
   defaultSender?: string;
   defaultGas?: number;
+  defaultGasPrice?: number;
 }
 
 interface Loader {
@@ -44,8 +45,9 @@ abstract class BaseLoader implements Loader {
   provider: any;
   defaultSender?: string;
   defaultGas?: number;
+  defaultGasPrice?: number;
 
-  constructor(providerOrWeb3: any, defaultSender?: string, defaultGas?: number) {
+  constructor(providerOrWeb3: any, defaultSender?: string, defaultGas?: number, defaultGasPrice?: number) {
     if (providerOrWeb3.currentProvider) {
       this.provider = providerOrWeb3.currentProvider;
       this.web3 = providerOrWeb3;
@@ -55,6 +57,7 @@ abstract class BaseLoader implements Loader {
 
     this.defaultSender = defaultSender;
     this.defaultGas = defaultGas;
+    this.defaultGasPrice = defaultGasPrice;
   }
 
   public fromArtifact(contract: string, address?: string): any {
@@ -69,7 +72,12 @@ export class Web3Loader extends BaseLoader {
   private _web3Contract: any;
 
   public fromABI(abi: object, bytecode?: string, address?: string): any {
-    return new this.web3Contract(abi, address, { data: bytecode, from: this.defaultSender, gas: this.defaultGas });
+    return new this.web3Contract(abi, address, {
+      data: bytecode,
+      from: this.defaultSender,
+      gas: this.defaultGas,
+      gasPrice: this.defaultGasPrice,
+    });
   }
 
   protected get web3Contract(): any {
@@ -102,7 +110,11 @@ export class TruffleLoader extends BaseLoader {
     // eslint-disable-next-line @typescript-eslint/camelcase
     const abstraction = this.truffleContract({ abi, unlinked_binary: bytecode });
     abstraction.setProvider(this.provider);
-    abstraction.defaults({ from: this.defaultSender, gas: this.defaultGas });
+    abstraction.defaults({
+      from: this.defaultSender,
+      gas: this.defaultGas,
+      gasPrice: this.defaultGasPrice,
+    });
 
     if (address !== undefined) return new abstraction(address);
     return abstraction;
@@ -122,9 +134,9 @@ export class TruffleLoader extends BaseLoader {
   }
 }
 
-export function setupLoader({ provider, defaultSender, defaultGas = 4e6 }: LoaderConfig) {
+export function setupLoader({ provider, defaultSender, defaultGas = 4e6, defaultGasPrice = 1e9 }: LoaderConfig) {
   return {
-    web3: new Web3Loader(provider, defaultSender, defaultGas),
-    truffle: new TruffleLoader(provider, defaultSender, defaultGas),
+    web3: new Web3Loader(provider, defaultSender, defaultGas, defaultGasPrice),
+    truffle: new TruffleLoader(provider, defaultSender, defaultGas, defaultGasPrice),
   };
 }

--- a/test/direct-dependency/test/Foo.test.js
+++ b/test/direct-dependency/test/Foo.test.js
@@ -77,9 +77,9 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.options.from).to.be.undefined;
         });
 
-        it('default gas is 4 million', async function() {
+        it('default gas is 200k', async function() {
           const Foo = web3Loader.fromArtifact('Foo');
-          expect(Foo.options.gas).to.equal(4e6);
+          expect(Foo.options.gas).to.equal(2e5);
         });
 
         it('default gas price is 1 gwei', async function() {
@@ -140,9 +140,9 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.defaults().from).to.be.undefined;
         });
 
-        it('default gas is 4 million', async function() {
+        it('default gas is 200k', async function() {
           const Foo = truffleLoader.fromArtifact('Foo');
-          expect(Foo.defaults().gas).to.equal(4e6);
+          expect(Foo.defaults().gas).to.equal(2e5);
         });
 
         it('default gas price is 1 gwei', async function() {

--- a/test/direct-dependency/test/Foo.test.js
+++ b/test/direct-dependency/test/Foo.test.js
@@ -65,6 +65,7 @@ function testTruffleLoaderWithDefaults(loader) {
 
 contract('direct-dependency', function([defaultSender]) {
   const defaultGas = 5e6;
+  const defaultGasPrice = 2e9;
 
   describe('project contracts', async function() {
     describe('web3 contracts', function() {
@@ -81,6 +82,11 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.options.gas).to.equal(4e6);
         });
 
+        it('default gas price is 1 gwei', async function() {
+          const Foo = web3Loader.fromArtifact('Foo');
+          expect(Foo.options.gasPrice).to.equal(1e9.toString());
+        });
+
         it('throws if the contract does not exist', async function() {
           expect(() => web3Loader.fromArtifact('Baz')).to.throw();
         });
@@ -91,6 +97,7 @@ contract('direct-dependency', function([defaultSender]) {
           provider: web3.eth.currentProvider,
           defaultSender,
           defaultGas,
+          defaultGasPrice,
         }).web3;
 
         it('default sender is set', async function() {
@@ -101,6 +108,11 @@ contract('direct-dependency', function([defaultSender]) {
         it('default gas is set', async function() {
           const Foo = web3Loader.fromArtifact('Foo');
           expect(Foo.options.gas).to.equal(defaultGas);
+        });
+
+        it('default gas price is set', async function() {
+          const Foo = web3Loader.fromArtifact('Foo');
+          expect(Foo.options.gasPrice.toString()).to.equal(defaultGasPrice.toString());
         });
 
         testWeb3LoaderWithDefaults(web3Loader);
@@ -133,6 +145,11 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.defaults().gas).to.equal(4e6);
         });
 
+        it('default gas price is 1 gwei', async function() {
+          const Foo = truffleLoader.fromArtifact('Foo');
+          expect(Foo.defaults().gasPrice.toString()).to.equal(1e9.toString());
+        });
+
         it('throws if the contract does not exist', async function() {
           expect(() => truffleLoader.fromArtifact('Baz')).to.throw();
         });
@@ -143,6 +160,7 @@ contract('direct-dependency', function([defaultSender]) {
           provider: web3.eth.currentProvider,
           defaultSender,
           defaultGas,
+          defaultGasPrice,
         }).truffle;
 
         it('default sender is set', async function() {
@@ -153,6 +171,11 @@ contract('direct-dependency', function([defaultSender]) {
         it('default gas is set', async function() {
           const Foo = truffleLoader.fromArtifact('Foo');
           expect(Foo.defaults().gas).to.equal(defaultGas);
+        });
+
+        it('default gas price is set', async function() {
+          const Foo = truffleLoader.fromArtifact('Foo');
+          expect(Foo.defaults().gasPrice.toString()).to.equal(defaultGasPrice.toString());
         });
 
         testTruffleLoaderWithDefaults(truffleLoader);

--- a/test/direct-dependency/test/Foo.test.js
+++ b/test/direct-dependency/test/Foo.test.js
@@ -76,9 +76,9 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.options.from).to.be.undefined;
         });
 
-        it('default gas is 8 million', async function() {
+        it('default gas is 4 million', async function() {
           const Foo = web3Loader.fromArtifact('Foo');
-          expect(Foo.options.gas).to.equal(8e6);
+          expect(Foo.options.gas).to.equal(4e6);
         });
 
         it('throws if the contract does not exist', async function() {
@@ -128,9 +128,9 @@ contract('direct-dependency', function([defaultSender]) {
           expect(Foo.defaults().from).to.be.undefined;
         });
 
-        it('default gas is 8 million', async function() {
+        it('default gas is 4 million', async function() {
           const Foo = truffleLoader.fromArtifact('Foo');
-          expect(Foo.defaults().gas).to.equal(8e6);
+          expect(Foo.defaults().gas).to.equal(4e6);
         });
 
         it('throws if the contract does not exist', async function() {


### PR DESCRIPTION
This PR tweaks the loader options by:
- Making default sender and gas fully optional
- Reducing the default gas from 8M to 200k (fixes #13)
- Adding gas price as another option